### PR TITLE
correção para baixar arquivo com extensões maiores que 3 caracteres

### DIFF
--- a/asd-core/src/main/java/br/com/delogic/asd/content/ContentController.java
+++ b/asd-core/src/main/java/br/com/delogic/asd/content/ContentController.java
@@ -72,12 +72,9 @@ public class ContentController {
     }
 
     private String getNomeComExtensao(String nome, String file) {
-
-        if (file.contains(".") &&
-            file.lastIndexOf(".") == file.length() - 4) {
+        if (file.contains(".")) {
             return nome + file.substring(file.lastIndexOf("."), file.length());
         }
-
         return nome;
     }
 


### PR DESCRIPTION
não era possível baixar por exemplo um arquivo .docx, ele vinha sem extensão